### PR TITLE
Added jsonb support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+* Added support for Supabase's `jsonb` format, same as json
+
 ## 0.1.0
 
 * Added serialization to and from snake case whilst generating camel case property names

--- a/lib/services/spec_parser.dart
+++ b/lib/services/spec_parser.dart
@@ -87,6 +87,7 @@ class SpecParser {
       case 'array':
         return 'List'; // You might need to handle the items of the array
       case 'json':
+      case 'jsonb':
         return 'dynamic';
       case 'number':
         return 'double';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_openapi_model_gen
 description: Generator for typed models of Swagger definitions and Supabase databases
-version: 0.1.0
+version: 0.1.1
 repository: https://github.com/ddikman/dart-openapi-model-gen
 
 environment:


### PR DESCRIPTION
Fixes error when trying to generate supabase models with `jsonb`

```
#0      SpecParser._parseModel (package:dart_openapi_model_gen/services/spec_parser.dart:51:7)
#1      SpecParser._parseDefinitions.<anonymous closure> (package:dart_openapi_model_gen/services/spec_parser.dart:25:40)
#2      MappedIterator.moveNext (dart:_internal/iterable.dart:403:20)
#3      new _GrowableList._ofOther (dart:core-patch/growable_array.dart:202:26)
#4      new _GrowableList.of (dart:core-patch/growable_array.dart:152:26)
#5      new List.of (dart:core-patch/array_patch.dart:39:18)
#6      Iterable.toList (dart:core/iterable.dart:497:7)
#7      SpecParser._parseDefinitions (package:dart_openapi_model_gen/services/spec_parser.dart:25:69)
#8      SpecParser.parse (package:dart_openapi_model_gen/services/spec_parser.dart:16:16)
#9      main (file:///Users/ddikman/code/dart-openapi-model-gen/bin/dart_openapi_model_gen.dart:62:14)
<asynchronous suspension>`
```