### PR TITLE
Deserializing doubles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+* Fixed problem with deserializing doubles
+
 ## 0.1.1
 
 * Added support for Supabase's `jsonb` format, same as json

--- a/lib/services/model_generator.dart
+++ b/lib/services/model_generator.dart
@@ -1,5 +1,6 @@
 import 'package:dart_openapi_model_gen/models/enum_model.dart';
 import 'package:dart_openapi_model_gen/models/model.dart';
+import 'package:dart_openapi_model_gen/models/model_property.dart';
 import 'package:dart_openapi_model_gen/models/type_category.dart';
 import 'package:dart_openapi_model_gen/string_helpers.dart';
 
@@ -69,7 +70,7 @@ class ModelGenerator {
       } else {
         final optionalMarker = property.isOptional ? '?' : '';
         output.writeln(
-            '        ${property.name}: json[\'${property.originalName}\'] as ${property.type}$optionalMarker,');
+            '        ${property.name}: ${_fromJson(property)}$optionalMarker,');
       }
     }
     output.writeln('  );');
@@ -78,6 +79,13 @@ class ModelGenerator {
     output.writeln('}');
 
     return output.toString();
+  }
+
+  static String _fromJson(ModelProperty property) {
+    if (property.type == 'double') {
+      return 'json[\'${property.originalName}\'].toDouble()';
+    }
+    return 'json[\'${property.originalName}\'] as ${property.type}';
   }
 
   static String generateEnum(EnumModel enumeration) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_openapi_model_gen
 description: Generator for typed models of Swagger definitions and Supabase databases
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/ddikman/dart-openapi-model-gen
 
 environment:


### PR DESCRIPTION
As doubles in json can be both formats like `450` and `450.0` we have to use `toDouble` to avoid type issues.