### PR TITLE
Added missing period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.6
+
+* Fixed bug in casting arrays of values such as `.cast<String>` which was missing a period
+
 ## 0.1.5
 
 * Generation syntax fix

--- a/lib/services/model_generator.dart
+++ b/lib/services/model_generator.dart
@@ -88,7 +88,7 @@ class ModelGenerator {
 
     if (property.isList) {
       final asOptional = optionalMarker.isEmpty ? '' : '$optionalMarker.';
-      final castCall = '${property.type.replaceAll('List', 'cast')}()';
+      final castCall = '${property.type.replaceAll('List', '.cast')}()';
       return 'json[\'${property.originalName}\']$asOptional$castCall';
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_openapi_model_gen
 description: Generator for typed models of Swagger definitions and Supabase databases
-version: 0.1.5
+version: 0.1.6
 repository: https://github.com/ddikman/dart-openapi-model-gen
 
 environment:


### PR DESCRIPTION
# Overview

Fixes missing period in generating arrays.

## Change

Before it generated:

```dart
factory ModelName.fromJson(Map<String, dynamic> json) => ModelName(
        propertyName: json['property_name']cast<String>(),
  );
```

Now it properly adds the dot:
```dart
factory ModelName.fromJson(Map<String, dynamic> json) => ModelName(
        propertyName: json['property_name'].cast<String>(),
  );
```